### PR TITLE
Ignore trailing characters in http status messages

### DIFF
--- a/src/s3_lib.erl
+++ b/src/s3_lib.erl
@@ -122,12 +122,12 @@ do_request(Url, Method, Headers, Body, Timeout, Options) ->
     case lhttpc:request(Url, Method, Headers, Body, Timeout, Options) of
         {ok, {{200, _}, ResponseHeaders, ResponseBody}} ->
             {ok, ResponseHeaders, ResponseBody};
-        {ok, {{204, "No Content"}, _, _}} ->
+        {ok, {{204, "No Content" ++ _}, _, _}} ->
             {ok, not_found};
-        {ok, {{307, "Temporary Redirect"}, ResponseHeaders, _ResponseBody}} ->
+        {ok, {{307, "Temporary Redirect" ++ _}, ResponseHeaders, _ResponseBody}} ->
             {"Location", Location} = lists:keyfind("Location", 1, ResponseHeaders),
             do_request(Location, Method, Headers, Body, Timeout, Options);
-        {ok, {{404, "Not Found"}, _, _}} ->
+        {ok, {{404, "Not Found" ++ _}, _, _}} ->
             {ok, not_found};
         {ok, {Code, _ResponseHeaders, <<>>}} ->
             {error, Code};


### PR DESCRIPTION
This is not so much an issue with S3 but rather with the jubos/fake-s3 ruby app
