### PR TITLE
Depend on inets

### DIFF
--- a/src/s3erl.app.src
+++ b/src/s3erl.app.src
@@ -5,6 +5,7 @@
   {registered, []},
   {applications, [kernel,
                   stdlib,
+                  inets,
                   lhttpc
                  ]},
   {env, [{retries, 5},{retry_delay, 50},{timeout, 1000},{worker, 50}]}


### PR DESCRIPTION
Add dependency on `inets` so `s3erl` can be included properly in releases.
