### PR TITLE
Allow headers in get and support If-None-Match

### DIFF
--- a/src/s3.erl
+++ b/src/s3.erl
@@ -23,13 +23,23 @@
                  {ok, [ResponseHeaders::header()], Body::value()} |
                  {ok, Body::value()} | term().
 get(Bucket, Key) ->
-    get(Bucket, Key, 5000).
+    get(Bucket, Key, 5000, []).
 
--spec get(Bucket::bucket(), Key::key(), timeout()) ->
+-spec get(Bucket::bucket(), Key::key(), timeout() | [header()]) ->
                  {ok, [ResponseHeaders::header()], Body::value()} |
-                 {ok, Body::value()} | term().
-get(Bucket, Key, Timeout) ->
-    call({request, {get, Bucket, Key}}, Timeout).
+                 {ok, Body::value()} | term() |
+                 {ok, not_modified}.
+get(Bucket, Key, Timeout) when is_integer(Timeout) ->
+    get(Bucket, Key, Timeout, []);
+get(Bucket, Key, Headers) when is_list(Headers) ->
+    get(Bucket, Key, 5000, Headers).
+
+-spec get(Bucket::bucket(), Key::key(), [header()], timeout()) ->
+                 {ok, [ResponseHeaders::header()], Body::value()} |
+                 {ok, Body::value()} | term() |
+                 {ok, not_modified}.
+get(Bucket, Key, Timeout, Headers) ->
+    call({request, {get, Bucket, Key, Headers}}, Timeout).
 
 
 put(Bucket, Key, Value, ContentType) ->

--- a/src/s3_lib.erl
+++ b/src/s3_lib.erl
@@ -4,7 +4,7 @@
 -module(s3_lib).
 
 %% API
--export([get/3, put/6, delete/3, list/5]).
+-export([get/4, put/6, delete/3, list/5]).
 
 -include_lib("xmerl/include/xmerl.hrl").
 -include("../include/s3.hrl").
@@ -13,9 +13,10 @@
 %% API
 %%
 
--spec get(#config{}, bucket(), key()) -> {ok, body()} | {error, any()}.
-get(Config, Bucket, Key) ->
-    do_get(Config, Bucket, Key).
+-spec get(#config{}, bucket(), key(), [header()]) ->
+                 {ok, body()} | {error, any()}.
+get(Config, Bucket, Key, Headers) ->
+    do_get(Config, Bucket, Key, Headers).
 
 -spec put(#config{}, bucket(), key(), body(), contenttype(), [header()]) ->
                  {ok, etag()} | {error, any()}.
@@ -67,11 +68,11 @@ do_put(Config, Bucket, Key, Value, Headers) ->
             Error
     end.
 
-do_get(Config, Bucket, Key) ->
-    case request(Config, get, Bucket, Key, [], <<>>) of
-        {ok, Headers, Body} ->
+do_get(Config, Bucket, Key, Headers) ->
+    case request(Config, get, Bucket, Key, Headers, <<>>) of
+        {ok, ResponseHeaders, Body} ->
             if Config#config.return_headers ->
-                    {ok, Headers, Body};
+                    {ok, ResponseHeaders, Body};
                true ->
                     {ok, Body}
             end;

--- a/src/s3_server.erl
+++ b/src/s3_server.erl
@@ -177,8 +177,8 @@ handle_request(Req, C, Attempts) ->
             Res
     end.
 
-execute_request({get, Bucket, Key}, C) ->
-    s3_lib:get(C, Bucket, Key);
+execute_request({get, Bucket, Key, Headers}, C) ->
+    s3_lib:get(C, Bucket, Key, Headers);
 execute_request({put, Bucket, Key, Value, ContentType, Headers}, C) ->
     s3_lib:put(C, Bucket, Key, Value, ContentType, Headers);
 execute_request({delete, Bucket, Key}, C) ->
@@ -186,7 +186,7 @@ execute_request({delete, Bucket, Key}, C) ->
 execute_request({list, Bucket, Prefix, MaxKeys, Marker}, C) ->
     s3_lib:list(C, Bucket, Prefix, MaxKeys, Marker).
 
-request_method({get, _, _})          -> get;
+request_method({get, _, _, _})       -> get;
 request_method({put, _, _, _, _, _}) -> put;
 request_method({delete, _, _})       -> delete;
 request_method({list, _, _, _, _})   -> get.

--- a/test/s3_test.erl
+++ b/test/s3_test.erl
@@ -55,7 +55,7 @@ concurrency_limit() ->
                           {max_concurrency, 3}] ++ default_config()),
 
     meck:new(s3_lib),
-    GetF = fun (_, _, _) -> timer:sleep(10), {ok, <<"bazbar">>} end,
+    GetF = fun (_, _, _, _) -> timer:sleep(50), {ok, <<"bazbar">>} end,
     meck:expect(s3_lib, get, GetF),
 
     P1 = spawn(fun() -> Parent ! {self(), s3:get(bucket(), <<"foo">>)} end),
@@ -174,7 +174,7 @@ callback_test() ->
     receive M2 ->
             fun () ->
                     {Request, Response, _ElapsedUs} = M2,
-                    ?assertEqual({get, bucket(), "foo"}, Request),
+                    ?assertEqual({get, bucket(), "foo", []}, Request),
                     ?assertEqual({ok, <<"bar">>}, Response)
             end()
     end,

--- a/test/s3_test.erl
+++ b/test/s3_test.erl
@@ -55,11 +55,8 @@ concurrency_limit() ->
                           {max_concurrency, 3}] ++ default_config()),
 
     meck:new(s3_lib),
-    GetF = fun (_, _, _) -> timer:sleep(50), {ok, <<"bazbar">>} end,
+    GetF = fun (_, _, _) -> timer:sleep(10), {ok, <<"bazbar">>} end,
     meck:expect(s3_lib, get, GetF),
-    meck:expect(s3_lib, get, GetF),
-    meck:expect(s3_lib, get, GetF),
-
 
     P1 = spawn(fun() -> Parent ! {self(), s3:get(bucket(), <<"foo">>)} end),
     P2 = spawn(fun() -> Parent ! {self(), s3:get(bucket(), <<"foo">>)} end),
@@ -67,10 +64,11 @@ concurrency_limit() ->
     P4 = spawn(fun() -> Parent ! {self(), s3:get(bucket(), <<"foo">>)} end),
 
     receive M0 -> ?assertEqual({max_concurrency, 3}, M0) end,
-    receive {P1, M1} -> ?assertEqual({ok, <<"bazbar">>}, M1) end,
-    receive {P2, M2} -> ?assertEqual({ok, <<"bazbar">>}, M2) end,
-    receive {P3, M3} -> ?assertEqual({ok, <<"bazbar">>}, M3) end,
-    receive {P4, M4} -> ?assertEqual({error, max_concurrency}, M4) end,
+    ?assertEqual([{error, max_concurrency},
+                  {ok, <<"bazbar">>},
+                  {ok, <<"bazbar">>},
+                  {ok, <<"bazbar">>}],
+                 lists:sort([receive {P, M} -> M  end || P <- [P1,P2,P3,P4]])),
 
     ?assertEqual({ok, <<"bazbar">>}, s3:get(bucket(), <<"foo">>)),
     ?assertEqual({ok, [{puts, 0}, {gets, 4}, {deletes, 0}, {num_workers, 0}]},
@@ -138,12 +136,12 @@ list_objects() ->
 
 fold() ->
     %% Depends on earlier tests to setup data.
-    ?assertEqual([<<"1/1">>, <<"1/2">>, <<"1/3">>],
+    ?assertEqual([<<"1/3">>, <<"1/2">>, <<"1/1">>],
                  s3:fold(bucket(), "1/", fun(Key, Acc) -> [Key|Acc] end, [])),
 
      %% List all, includes keys from other tests.
-    ?assertEqual([<<"1/1">>, <<"1/2">>, <<"1/3">>, <<"2/1">>,
-                  <<"foo">>, <<"foo-copy">>],
+    ?assertEqual([<<"foo-copy">>, <<"foo">>, <<"2/1">>, <<"1/3">>, <<"1/2">>,
+                  <<"1/1">>],
                  s3:fold(bucket(), "", fun(Key, Acc) -> [Key|Acc] end, [])).
 
 callback_test() ->


### PR DESCRIPTION
This pull request fixes some broken tests, and adds header support to get and handling of `304 Not Modifed` as a response to support using `If-None-Match`.
