### PR TITLE
Add xmerl as a dependency

### DIFF
--- a/src/s3erl.app.src
+++ b/src/s3erl.app.src
@@ -6,6 +6,7 @@
   {applications, [kernel,
                   stdlib,
                   inets,
+                  xmerl,
                   lhttpc
                  ]},
   {env, [{retries, 5},{retry_delay, 50},{timeout, 1000},{worker, 50}]}


### PR DESCRIPTION
Without this dependency, s3erl is unusuable in releases.
